### PR TITLE
Refactor campaign page for session management

### DIFF
--- a/lidnd/app/[username]/[campaign_slug]/page.tsx
+++ b/lidnd/app/[username]/[campaign_slug]/page.tsx
@@ -12,13 +12,16 @@ import { CampaignId } from "@/app/[username]/[campaign_slug]/campaign_id";
 import Link from "next/link";
 import { Button } from "@/components/ui/button";
 import {
+  Calendar,
+  ChevronDown,
+  Ellipsis,
   MoveLeft,
   Plus,
-  Calendar,
+  Trash,
+  Trash2,
   BookIcon,
   Clock,
   MoreVertical,
-  Trash,
 } from "lucide-react";
 import { LidndDialog } from "@/components/ui/lidnd_dialog";
 import { db } from "@/server/db";
@@ -30,11 +33,11 @@ import { and, eq } from "drizzle-orm";
 import { EncounterUtils } from "@/utils/encounters";
 import { formatSeconds } from "@/lib/utils";
 import { Card } from "@/components/ui/card";
-import { LidndPopover } from "@/encounters/base-popover";
 import clsx from "clsx";
 import type { EncounterWithParticipants } from "@/server/api/router";
 import type { Campaign } from "@/app/[username]/types";
 import { deleteEncounter } from "@/app/[username]/actions";
+import { LidndPopover } from "@/encounters/base-popover";
 
 export default async function CampaignPage(props: {
   params: Promise<{
@@ -64,6 +67,8 @@ export default async function CampaignPage(props: {
     return <div>No campaign found... this is a bug</div>;
   }
 
+  const campaignRoute = appRoutes.campaign({ campaign: campaignData, user });
+
   if (searchParams?.game_session) {
     return (
       <GameSessionView
@@ -77,6 +82,14 @@ export default async function CampaignPage(props: {
     { user },
     campaignData.id
   );
+
+  const createdAtLabel = campaignData.created_at
+    ? new Intl.DateTimeFormat(undefined, { dateStyle: "medium" }).format(
+        campaignData.created_at instanceof Date
+          ? campaignData.created_at
+          : new Date(campaignData.created_at)
+      )
+    : null;
 
   async function createNewSession(form: FormData) {
     "use server";
@@ -106,30 +119,91 @@ export default async function CampaignPage(props: {
       user_id: user.id,
       campaign_id: campaignData.id,
     });
-    revalidatePath(appRoutes.campaign({ campaign: campaignData, user }));
+    revalidatePath(campaignRoute);
+  }
+
+  async function deleteSession(form: FormData) {
+    "use server";
+    if (!user) {
+      console.error("No user found, cannot delete session");
+      throw new Error("No user found");
+    }
+
+    const sessionId = form.get("session_id")?.toString();
+
+    if (!sessionId) {
+      throw new Error("Session id is required");
+    }
+
+    await db
+      .update(encounters)
+      .set({ session_id: null })
+      .where(
+        and(eq(encounters.session_id, sessionId), eq(encounters.user_id, user.id))
+      );
+
+    await db
+      .delete(gameSessions)
+      .where(
+        and(eq(gameSessions.id, sessionId), eq(gameSessions.user_id, user.id))
+      );
+
+    revalidatePath(campaignRoute);
+  }
+
+  async function removeEncounter(form: FormData) {
+    "use server";
+
+    const encounterId = form.get("encounter_id")?.toString();
+
+    if (!encounterId) {
+      throw new Error("Encounter id is required");
+    }
+
+    await deleteEncounter({ id: encounterId });
+    revalidatePath(campaignRoute);
   }
 
   return (
     <CampaignId value={campaignData.id}>
-      <div className="flex flex-col gap-6 p-4 max-w-6xl w-full mx-auto">
-        {/* Header */}
-        <div className="flex items-center justify-between">
-          <Link href={appRoutes.dashboard(user)}>
-            <Button variant="ghost" className="opacity-60 hover:opacity-100">
-              <MoveLeft className="mr-2 h-4 w-4" />
-              All campaigns
-            </Button>
-          </Link>
-          <CampaignParty campaign={campaignData} />
-
-          <div className="flex items-center gap-2">
-            <Calendar className="h-5 w-5 text-muted-foreground" />
-            <h1 className="text-2xl font-semibold">Sessions</h1>
+      <div className="mx-auto flex w-full max-w-5xl flex-col gap-8 px-4 py-6">
+        <header className="flex flex-col gap-6 border-b pb-6">
+          <div className="flex items-center justify-between gap-4">
+            <Link href={appRoutes.dashboard(user)}>
+              <Button variant="ghost" className="px-2 text-sm opacity-60 hover:opacity-100">
+                <MoveLeft className="mr-2 h-4 w-4" />
+                All campaigns
+              </Button>
+            </Link>
+            <CampaignParty campaign={campaignData} />
           </div>
-        </div>
 
-        <div className="flex flex-col gap-6">
-          <div className="flex justify-center">
+          <div className="flex flex-wrap items-end justify-between gap-4">
+            <div className="space-y-2">
+              <h1 className="text-3xl font-semibold tracking-tight">
+                {campaignData.name}
+              </h1>
+              {campaignData.description ? (
+                <p className="text-muted-foreground max-w-2xl text-sm">
+                  {campaignData.description}
+                </p>
+              ) : null}
+            </div>
+
+            <div className="flex flex-col items-end text-right text-sm text-muted-foreground">
+              {createdAtLabel ? <span>Created {createdAtLabel}</span> : null}
+              <span>{sessionsInCampaign.length} sessions</span>
+            </div>
+          </div>
+        </header>
+
+        <section className="flex flex-col gap-6">
+          <div className="flex flex-wrap items-center justify-between gap-4">
+            <div className="flex items-center gap-2">
+              <Calendar className="h-5 w-5 text-muted-foreground" />
+              <h2 className="text-xl font-semibold">Sessions</h2>
+            </div>
+
             <LidndDialog
               content={
                 <form action={createNewSession} className="flex flex-col gap-4">
@@ -140,6 +214,7 @@ export default async function CampaignPage(props: {
                       name="name"
                       placeholder="Enter session name"
                       className="w-full"
+                      required
                     />
                   </div>
                   <div className="space-y-2">
@@ -160,55 +235,160 @@ export default async function CampaignPage(props: {
               }
               title="Create New Session"
               trigger={
-                <Button
-                  variant="default"
-                  size="lg"
-                  className="px-8 py-6 text-base"
-                >
-                  <Plus className="mr-2 h-5 w-5" />
-                  Create New Session
+                <Button className="gap-2">
+                  <Plus className="h-4 w-4" />
+                  Add session
                 </Button>
               }
             />
           </div>
 
-          {sessionsInCampaign.length > 0 ? (
-            <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-              {sessionsInCampaign.map((session) => (
-                <Link
-                  key={session.id}
-                  href={appRoutes.gameSession({
-                    user,
-                    campaign: campaignData,
-                    gameSessionId: session.id,
-                  })}
-                  className="group"
-                >
-                  <div className="p-4 border rounded-lg hover:shadow-md transition-all duration-200 group-hover:border-primary/50 bg-card">
-                    <h3 className="font-medium text-lg mb-2 group-hover:text-primary transition-colors">
-                      {session.name}
-                    </h3>
-                    {session.description && (
-                      <p className="text-sm text-muted-foreground line-clamp-2">
-                        {session.description}
-                      </p>
-                    )}
-                  </div>
-                </Link>
-              ))}
+          {sessionsInCampaign.length === 0 ? (
+            <div className="rounded-lg border border-dashed py-16 text-center text-sm text-muted-foreground">
+              <p className="font-medium text-base text-foreground">
+                No sessions yet
+              </p>
+              <p>Create your first session to start organizing encounters.</p>
             </div>
           ) : (
-            <div className="text-center py-12">
-              <div className="text-muted-foreground">
-                <Calendar className="h-12 w-12 mx-auto mb-4 opacity-40" />
-                <p className="text-lg mb-2">No sessions yet</p>
-                <p className="text-sm">
-                  Create your first session to get started
-                </p>
-              </div>
+            <div className="space-y-4">
+              {sessionsInCampaign.map((session) => {
+                const encounterCount = session.encounters?.length ?? 0;
+
+                return (
+                  <details
+                    key={session.id}
+                    className="group rounded-lg border bg-card shadow-sm"
+                  >
+                    <summary className="flex cursor-pointer list-none items-center justify-between gap-4 px-5 py-4">
+                      <div className="flex items-start gap-3">
+                        <ChevronDown className="mt-1 h-4 w-4 shrink-0 text-muted-foreground transition-transform duration-200 group-open:rotate-180" />
+                        <div className="space-y-1">
+                          <p className="text-lg font-semibold leading-none">
+                            {session.name}
+                          </p>
+                          {session.description ? (
+                            <p className="text-sm text-muted-foreground">
+                              {session.description}
+                            </p>
+                          ) : null}
+                          <p className="text-xs text-muted-foreground">
+                            {encounterCount} encounter{encounterCount === 1 ? "" : "s"}
+                          </p>
+                        </div>
+                      </div>
+
+                      <div className="flex flex-wrap items-center justify-end gap-2">
+                        <Link
+                          href={appRoutes.gameSession({
+                            user,
+                            campaign: campaignData,
+                            gameSessionId: session.id,
+                          })}
+                        >
+                          <Button variant="outline" size="sm" className="gap-2">
+                            <Ellipsis className="h-4 w-4" />
+                            Manage session
+                          </Button>
+                        </Link>
+
+                        <form action={deleteSession}>
+                          <input type="hidden" name="session_id" value={session.id} />
+                          <Button variant="ghost" size="icon" className="text-destructive hover:text-destructive">
+                            <Trash2 className="h-4 w-4" />
+                            <span className="sr-only">Delete session</span>
+                          </Button>
+                        </form>
+                      </div>
+                    </summary>
+
+                    <div className="space-y-4 border-t px-5 py-4">
+                      {encounterCount === 0 ? (
+                        <div className="rounded-md border border-dashed px-4 py-6 text-center text-sm text-muted-foreground">
+                          No encounters yet in this session.
+                        </div>
+                      ) : (
+                        <ul className="space-y-3">
+                          {session.encounters?.map((encounter) => (
+                            <li
+                              key={encounter.id}
+                              className="flex flex-col gap-3 rounded-md border bg-background p-4 sm:flex-row sm:items-center sm:justify-between"
+                            >
+                              <div className="flex flex-col gap-3">
+                                <span className="text-base font-medium">
+                                  {encounter.name || "Unnamed encounter"}
+                                </span>
+                                {encounter.description ? (
+                                  <span className="text-sm text-muted-foreground line-clamp-2">
+                                    {encounter.description}
+                                  </span>
+                                ) : null}
+                                <div className="flex flex-wrap items-center gap-3">
+                                  <DifficultyBadge encounter={encounter} />
+                                  <MonstersInEncounter id={encounter.id} />
+                                </div>
+                              </div>
+
+                              <div className="flex flex-wrap items-center gap-2">
+                                <Link
+                                  href={appRoutes.observe(encounter.id)}
+                                  className="flex"
+                                >
+                                  <Button size="sm" variant="secondary">
+                                    View
+                                  </Button>
+                                </Link>
+                                <Link
+                                  href={appRoutes.encounter({
+                                    campaign: campaignData,
+                                    encounter,
+                                    user,
+                                  })}
+                                  className="flex"
+                                >
+                                  <Button size="sm" variant="outline">
+                                    Edit
+                                  </Button>
+                                </Link>
+                                <form action={removeEncounter}>
+                                  <input
+                                    type="hidden"
+                                    name="encounter_id"
+                                    value={encounter.id}
+                                  />
+                                  <Button
+                                    size="sm"
+                                    variant="ghost"
+                                    className="text-destructive hover:text-destructive"
+                                  >
+                                    Delete
+                                  </Button>
+                                </form>
+                              </div>
+                            </li>
+                          ))}
+                        </ul>
+                      )}
+
+                      <div className="flex flex-wrap items-center justify-end gap-3">
+                        <LidndDialog
+                          title={`Add encounter to ${session.name}`}
+                          content={<CreateEncounterForm gameSessionId={session.id} />}
+                          trigger={
+                            <Button size="sm" className="gap-2">
+                              <Plus className="h-4 w-4" />
+                              Add encounter
+                            </Button>
+                          }
+                        />
+                      </div>
+                    </div>
+                  </details>
+                );
+              })}
             </div>
           )}
-        </div>
+        </section>
       </div>
     </CampaignId>
   );


### PR DESCRIPTION
## Summary
- redesign the campaign page header to surface campaign context alongside the back navigation
- add an accordion session list with manage/delete actions and quick links to encounters, plus inline encounter creation dialogs
- introduce server actions to handle session creation, deletion, and encounter cleanup while revalidating the campaign view

## Testing
- pnpm lint *(fails: cannot find package '@typescript-eslint/parser')*

------
https://chatgpt.com/codex/tasks/task_e_68ebc286641483208654c3e2d86873b9

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- New Features
  - Redesigned campaign page with compact header showing title, description, creation date, and session count.
  - Collapsible session list with per-session actions: manage, delete, and add encounter.
  - In-session encounter management with view, edit, and delete actions; add encounter via dialog.
  - Friendly empty state for sessions and encounters, plus an “All campaigns” navigation button.
- Refactor
  - Streamlined layout, improved button labels (e.g., “Add session”), and accessibility tweaks (screen-reader labels).

<!-- end of auto-generated comment: release notes by coderabbit.ai -->