### PR TITLE
Tighten encounter health bar layout

### DIFF
--- a/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx
+++ b/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx
@@ -660,7 +660,7 @@ export const BattleCardCreatureIcon = observer(function BattleCardCreatureIcon({
   ) : (
     <div
       className={clsx(
-        "relative border-4 items-center flex justify-center",
+        "relative border-2 rounded-lg items-center flex justify-center p-1",
         className,
         {
           "opacity-50": !(uiStore.selectedParticipantId === participant.id),
@@ -669,7 +669,7 @@ export const BattleCardCreatureIcon = observer(function BattleCardCreatureIcon({
       style={{ borderColor: ParticipantUtils.iconHexColor(participant) }}
     >
       {error ? (
-        <User className="w-36 h-36" />
+        <User className="w-28 h-28" />
       ) : (
         <Image
           src={CreatureUtils.awsURL(participant.creature, "icon")}
@@ -677,7 +677,7 @@ export const BattleCardCreatureIcon = observer(function BattleCardCreatureIcon({
           style={imageStyle}
           width={participant.creature.icon_width}
           height={participant.creature.icon_height}
-          className="w-36 h-36"
+          className="w-28 h-28"
           onError={() => setError(true)}
         />
       )}

--- a/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/creature-health-form.tsx
+++ b/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/creature-health-form.tsx
@@ -70,12 +70,12 @@ export function ParticipantHealthForm({
   const hpPercent = ParticipantUtils.healthPercent(participant);
 
   return (
-    <div className="flex gap-5 flex-col w-full">
-      <div className="flex gap-4 text-2xl">
+    <div className="flex gap-3 flex-col w-full">
+      <div className="flex gap-3 text-lg flex-wrap">
         <Input
           placeholder="HP"
           type="number"
-          className="w-32"
+          className="w-28"
           value={hpDiff}
           onChange={(e) => {
             if (!isNaN(parseInt(e.target.value))) {
@@ -87,7 +87,7 @@ export function ParticipantHealthForm({
         />
         <Button
           variant="outline"
-          className={"bg-red-100 text-red-700 gap-3 flex items-center"}
+          className={"bg-red-100 text-red-700 gap-2 flex items-center text-base px-3"}
           onClick={(e) => {
             e.stopPropagation();
             handleHPChange(
@@ -101,7 +101,7 @@ export function ParticipantHealthForm({
         </Button>
         <Button
           variant="outline"
-          className={"bg-green-100 text-green-700 gap-3 flex items-center"}
+          className={"bg-green-100 text-green-700 gap-2 flex items-center text-base px-3"}
           onClick={(e) => {
             e.stopPropagation();
             handleHPChange(
@@ -114,8 +114,8 @@ export function ParticipantHealthForm({
           <Heart /> Heal
         </Button>
       </div>
-      <div className="flex max-w-full w-full gap-2">
-        <span className="w-full h-10 shadow-md relative border bg-red-100">
+      <div className="flex max-w-full w-full gap-2 items-center">
+        <span className="w-full h-8 shadow-md relative border bg-red-100 rounded-md">
           <span
             className={`absolute bg-green-500 h-full transition-all`}
             style={{
@@ -129,14 +129,17 @@ export function ParticipantHealthForm({
             }}
           />
           <span className="flex w-full items-center justify-center h-full">
-            <span className="z-10 text-xl text-white">
+            <span className="z-10 text-sm font-semibold text-white">
               {participant.hp} / {ParticipantUtils.maxHp(participant)}
             </span>
           </span>
         </span>
         <LidndPopover
           trigger={
-            <Button variant="outline" className="bg-blue-100 text-blue-700">
+            <Button
+              variant="outline"
+              className="bg-blue-100 text-blue-700 px-3 py-1 text-sm"
+            >
               <Shield /> Temp
             </Button>
           }


### PR DESCRIPTION
## Summary
- shrink the battle card creature icon with a lighter border so it occupies less vertical space
- compact the participant health form buttons and meter styling to give the stat block more room while retaining clarity

## Testing
- pnpm lint *(fails: missing dependency `@typescript-eslint/parser`)*

------
https://chatgpt.com/codex/tasks/task_e_68ec1a1f6c888320824c42ce50d25294

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Refined battle creature icon visuals: slimmer border, added padding, and reduced icon and error placeholder sizes for a cleaner look.
  * Updated health form layout: tighter spacing, smaller typography, and improved wrapping for better readability on varied screens.
  * Adjusted HP input width and button styling with clearer padding and base text size for consistency.
  * Enhanced health bar appearance: increased rounding, adjusted height, and centered content for improved clarity.
  * Minor alignment tweaks to overlays to match new sizing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->