### PR TITLE
Keep defeated monsters in encounter and show defeated state

### DIFF
--- a/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx
+++ b/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx
@@ -1101,6 +1101,9 @@ export const BattleCardLayout = observer(function BattleCardLayout({
           "shadow-lg shadow-blue-800":
             ParticipantUtils.isFriendly(participant) && participant.is_active,
         },
+        {
+          "opacity-60 grayscale": ParticipantUtils.isDead(participant),
+        },
         className,
       )}
       {...props}
@@ -1186,6 +1189,7 @@ export const BattleCardCreatureName = observer(function BattleCardCreatureName({
 }: BattleCardParticipantProps) {
   const [encounter] = useEncounter();
   const { mutate: updateParticipant } = useUpdateEncounterParticipant();
+  const isDead = ParticipantUtils.isDead(participant);
   return (
     <span className="flex gap-1 items-center">
       <LidndPopover
@@ -1201,6 +1205,11 @@ export const BattleCardCreatureName = observer(function BattleCardCreatureName({
             <span className="text-lg truncate max-w-full">
               {ParticipantUtils.name(participant)}
             </span>
+            {isDead ? (
+              <LidndTooltip text="Defeated">
+                <SkullIcon className="h-4 w-4 text-gray-500" />
+              </LidndTooltip>
+            ) : null}
           </Button>
         }
       >

--- a/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/hooks.ts
+++ b/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/hooks.ts
@@ -255,14 +255,11 @@ export function useUpdateEncounterParticipant() {
 
         if (newParticipant.hp <= 0) {
           // this should be a message to the system, draw steel/ dnd5e, because it depends
-
           // TODO: make sure that the next participant in the column gets
           // assigned the column id of this fallen monster, to avoid a weird switch
           if (newParticipant.is_active && campaign.system === "dnd5e") {
             cycleNext({ encounter_id: id });
           }
-
-          return EncounterUtils.removeParticipant(newParticipant.id, old);
         }
 
         return EncounterUtils.updateParticipant(newParticipant, old);

--- a/lidnd/server/sdk/participants.ts
+++ b/lidnd/server/sdk/participants.ts
@@ -17,24 +17,6 @@ export const ServerParticipants = {
       participant.encounter_id
     );
 
-    if (participant.hp !== undefined && participant.hp <= 0) {
-      // just remove the participant
-      const update = await dbObject
-        .delete(participants)
-        .where(eq(participants.id, participant.id))
-        .returning();
-      const updatedParticipant = update[0];
-
-      if (!updatedParticipant) {
-        throw new TRPCError({
-          code: "INTERNAL_SERVER_ERROR",
-          message: "Failed to update encounter participant",
-        });
-      }
-
-      return updatedParticipant;
-    }
-
     const update = await dbObject
       .update(participants)
       .set(participant)


### PR DESCRIPTION
### Motivation
- Avoid immediately removing monsters when their HP reaches 0 so the GM can still see defeated participants in the encounter and maintain turn continuity. 
- Provide a clear visual affordance (death icon + muted styling) for participants with HP <= 0 to indicate defeated state without removing them.

### Description
- Update optimistic client update in `app/[username]/[campaign_slug]/encounter/[encounter_index]/hooks.ts` so `useUpdateEncounterParticipant` no longer removes participants when `hp <= 0`, but still advances the turn for an active participant under the `dnd5e` system. 
- Change server behavior in `server/sdk/participants.ts` so `ServerParticipants.updateParticipant` always updates the participant row instead of deleting it when `hp <= 0`.
- Add defeated visual state in `app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx` by applying `opacity-60 grayscale` to `BattleCardLayout` when `ParticipantUtils.isDead(participant)` and by showing a `SkullIcon` tooltip labeled `"Defeated"` next to the creature name when dead.

### Testing
- Ran targeted ESLint on the changed files with `pnpm -s exec eslint app/[username]/[campaign_slug]/encounter/[encounter_index]/hooks.ts app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx server/sdk/participants.ts` which completed with no errors and a single React Hook warning. 
- Ran the repo lint `pnpm -s lint`, which failed due to pre-existing, unrelated repo-wide lint issues (not introduced by these changes). 
- Changes were committed with message `Keep defeated monsters in encounter with defeated styling`.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69dfb6ae68ac8320836657693544810c)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Defeated creatures now display visual indicators: reduced opacity with a grayscale effect and a "Defeated" icon label to make their status immediately clear during encounters.

* **Bug Fixes**
  * Defeated creatures remain in the encounter instead of being unexpectedly removed, allowing proper encounter tracking and round management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->