### PR TITLE
Refine encounter prep form layout and move secondary actions into More popover

### DIFF
--- a/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx
+++ b/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx
@@ -152,7 +152,7 @@ const encounterPrepForms = [
 type EncounterPrepForm = (typeof encounterPrepForms)[number];
 
 const isEncounterPrepForm = (
-  value: string | null | undefined,
+  value: string | null | undefined
 ): value is EncounterPrepForm =>
   value != null && (encounterPrepForms as readonly string[]).includes(value);
 
@@ -176,7 +176,7 @@ const readEncounterPrepFormCookie = (): EncounterPrepForm | null => {
 
 const persistEncounterPrepFormCookie = (value: EncounterPrepForm) => {
   document.cookie = `${ENCOUNTER_PREP_FORM_COOKIE_NAME}=${encodeURIComponent(
-    value,
+    value
   )}; path=/; max-age=${ENCOUNTER_PREP_FORM_COOKIE_MAX_AGE}`;
 };
 
@@ -210,7 +210,7 @@ export const EncounterBattleUI = observer(function BattleUI() {
     EncounterUtils.participantsWithNoColumn(encounter);
 
   const [activePrepForm, setActivePrepForm] = useState<EncounterPrepForm>(
-    monsters.length === 0 ? "participants" : "notes",
+    monsters.length === 0 ? "participants" : "notes"
   );
 
   useEffect(() => {
@@ -237,7 +237,7 @@ export const EncounterBattleUI = observer(function BattleUI() {
           <div
             className={clsx(
               "flex w-full xl:max-h-full flex-wrap lg:flex-nowrap pt-5 px-10 gap-5",
-              battleStyles.root,
+              battleStyles.root
             )}
           >
             <div className="flex gap-5 flex-col w-full">
@@ -283,14 +283,14 @@ export const EncounterBattleUI = observer(function BattleUI() {
               ) : null}
 
               <div className="flex flex-wrap lg:flex-nowrap gap-5 items-start">
-                <div className="w-full max-w-[500px] 2xl:w-[550px] 2xl:min-w-[550px] flex flex-col gap-3">
+                <Card className="w-full max-w-[800px] flex flex-col gap-3 min-h-[320px] h-full overflow-auto p-4 shadow-sm">
                   <EncounterPrepFormChooser
                     activeForm={activePrepForm}
                     onFormChange={setActivePrepForm}
                     showTurnGroups={monsters.length > 0}
                   />
                   <EncounterPrepFormPanel activeForm={activePrepForm} />
-                </div>
+                </Card>
                 <div
                   className="w-full min-w-0 xl:max-h-full flex flex-col gap-3"
                   data-value="prep"
@@ -441,7 +441,7 @@ function DifficultyBadgePopover() {
         <button
           className={clsx(
             "rounded-md px-2 py-1 text-center cursor-pointer hover:opacity-80 transition-opacity flex flex-col items-center min-w-[90px]",
-            difficultyCssClass,
+            difficultyCssClass
           )}
         >
           <span className="text-sm font-medium">{difficulty}</span>
@@ -474,7 +474,7 @@ function EncounterDifficultyDashboard({ className }: { className?: string }) {
   const remainingCr = EncounterUtils.remainingCr(encounter, campaign);
   const isAtTargetDifficulty = EncounterUtils.isAtTargetDifficulty(
     encounter,
-    campaign,
+    campaign
   );
 
   return (
@@ -486,7 +486,7 @@ function EncounterDifficultyDashboard({ className }: { className?: string }) {
             <span
               className={clsx(
                 "font-semibold",
-                difficultyCssClass.split(" ")[0],
+                difficultyCssClass.split(" ")[0]
               )}
             >
               {difficulty}
@@ -589,7 +589,7 @@ export interface RemoveCreatureFromEncounterButtonProps {
 }
 
 export function RemoveCreatureFromEncounterButton(
-  props: RemoveCreatureFromEncounterButtonProps,
+  props: RemoveCreatureFromEncounterButtonProps
 ) {
   const { participant } = props;
 
@@ -679,12 +679,12 @@ function SliderTier({ difficulty }: { difficulty: Difficulty }) {
     color === "gray"
       ? "bg-gray-400"
       : color === "blue"
-        ? "bg-blue-400"
-        : color === "green"
-          ? "bg-green-400"
-          : color === "yellow"
-            ? "bg-yellow-400"
-            : "bg-red-400";
+      ? "bg-blue-400"
+      : color === "green"
+      ? "bg-green-400"
+      : color === "yellow"
+      ? "bg-yellow-400"
+      : "bg-red-400";
 
   return (
     <div
@@ -816,7 +816,7 @@ function PreviewCardsForColumn({ column }: { column: StatColumn }) {
   const [encounter] = useEncounter();
   const participantsInColumn = EncounterUtils.participantsForColumn(
     encounter,
-    column,
+    column
   );
   const uiStore = useEncounterUIStore();
 
@@ -1008,7 +1008,7 @@ export const GroupParticipantHPOverride = observer(
   }) {
     const uiStore = useEncounterUIStore();
     const [maxHpOverride, setMaxHpOverride] = useState(
-      participant.max_hp_override?.toString() ?? "",
+      participant.max_hp_override?.toString() ?? ""
     );
     const { mutate: updateParticipant } = useUpdateEncounterParticipant();
     if (!uiStore.isEditingInitiative) {
@@ -1043,7 +1043,7 @@ export const GroupParticipantHPOverride = observer(
         </Button>
       </div>
     );
-  },
+  }
 );
 
 export function EqualizeColumnsButton(props?: {
@@ -1054,10 +1054,10 @@ export function EqualizeColumnsButton(props?: {
   const [encounter] = useEncounter();
 
   const sumColumnPercents = Math.round(
-    R.sumBy(encounter.columns, (c) => c.percent_width),
+    R.sumBy(encounter.columns, (c) => c.percent_width)
   );
   const aNegativeWidthColumn = encounter.columns.find(
-    (c) => c.percent_width < 0,
+    (c) => c.percent_width < 0
   );
   return (
     <ButtonWithTooltip
@@ -1077,7 +1077,7 @@ export function EqualizeColumnsButton(props?: {
         : null}
       {aNegativeWidthColumn && aNegativeWidthColumn.participants[0]
         ? `column ${ParticipantUtils.name(
-            aNegativeWidthColumn.participants[0],
+            aNegativeWidthColumn.participants[0]
           )} has negative width, click me`
         : null}
     </ButtonWithTooltip>
@@ -1109,7 +1109,7 @@ export const BattleCardLayout = observer(function BattleCardLayout({
         {
           "opacity-60 grayscale": ParticipantUtils.isDead(participant),
         },
-        className,
+        className
       )}
       {...props}
     >
@@ -1182,7 +1182,7 @@ function TurnGroupLabel({
     <span
       className={clsx(
         "inline-block h-5 w-5 shrink-0 rounded-sm shadow-lg",
-        className,
+        className
       )}
       style={{ background: hex_color ?? "" }}
     />
@@ -1260,10 +1260,10 @@ export const BattleCardCreatureIcon = observer(function BattleCardCreatureIcon({
 
           "opacity-50": EncounterUtils.participantHasPlayed(
             encounter,
-            participant,
+            participant
           ),
         },
-        "relative flex flex-shrink-0 h-10 w-10",
+        "relative flex flex-shrink-0 h-10 w-10"
       )}
       style={{ borderColor: ParticipantUtils.iconHexColor(participant) }}
     >
@@ -1299,7 +1299,7 @@ export function HealthMeterOverlay({
         {
           "bg-gray-500": percentDamage >= 100,
           "bg-red-500": percentDamage !== 100,
-        },
+        }
       )}
     />
   );
@@ -1345,7 +1345,7 @@ function PrepParticipant({
         {
           "border-none shadow-none": tgForParticipant,
           "cursor-grab": encounter.turn_groups.length > 0,
-        },
+        }
       )}
       draggable={encounter.turn_groups.length > 0}
       onDragStart={(e) => {
@@ -1468,8 +1468,9 @@ function EncounterPrepFormChooser({
           <Button
             variant="ghost"
             className={clsx("gap-2", {
-              "bg-secondary text-secondary-foreground":
-                secondaryChoices.some((choice) => choice.form === activeForm),
+              "bg-secondary text-secondary-foreground": secondaryChoices.some(
+                (choice) => choice.form === activeForm
+              ),
             })}
           >
             <MoreHorizontal className="h-5 w-5" />
@@ -1502,16 +1503,14 @@ function EncounterPrepFormPanel({
   activeForm: EncounterPrepForm;
 }) {
   return (
-    <Card className="w-full min-h-[320px] h-full overflow-auto p-4 shadow-sm">
-      <div className="flex flex-col gap-4 h-full">
-        {activeForm === "notes" && <DescriptionTextArea />}
-        {activeForm === "participants" && <EditModeOpponentForm />}
-        {activeForm === "partyMembers" && <AddPlayerToEncounter inline />}
-        {activeForm === "images" && <ImageAssetAddButton inline />}
-        {activeForm === "reminders" && <ReminderInput inline />}
-        {activeForm === "turnGroups" && <CreateTurnGroupForm inline />}
-      </div>
-    </Card>
+    <div className="flex flex-col gap-4 h-full">
+      {activeForm === "notes" && <DescriptionTextArea />}
+      {activeForm === "participants" && <EditModeOpponentForm />}
+      {activeForm === "partyMembers" && <AddPlayerToEncounter inline />}
+      {activeForm === "images" && <ImageAssetAddButton inline />}
+      {activeForm === "reminders" && <ReminderInput inline />}
+      {activeForm === "turnGroups" && <CreateTurnGroupForm inline />}
+    </div>
   );
 }
 
@@ -1548,13 +1547,13 @@ const MonsterSection = observer(function TurnGroupSetup() {
                     "border-dashed": uiStore.activeDragType === "participant",
                     "border-transparent":
                       uiStore.activeDragType !== "participant",
-                  },
+                  }
                 )}
                 onDrop={(e) => {
                   e.preventDefault();
                   const droppedParticipant = typedDrag.get(
                     e.dataTransfer,
-                    dragTypes.participant,
+                    dragTypes.participant
                   );
                   if (droppedParticipant) {
                     updateParticipant({
@@ -1716,8 +1715,8 @@ export function ImageAssetAddButton({ inline = false }: { inline?: boolean }) {
               !imageName.trim()
                 ? "Enter a name first"
                 : isUploading
-                  ? "Uploading..."
-                  : "Drop image to upload"
+                ? "Uploading..."
+                : "Drop image to upload"
             }
             dropIcon={<ImageIcon />}
             fileInputProps={{ disabled: isUploading || !imageName.trim() }}
@@ -1804,7 +1803,7 @@ const TurnGroupDisplay = observer(function TurnGroupDisplay({
   const { mutate: deleteTurnGroup } = api.deleteTurnGroup.useMutation();
   const { mutate: updateParticipant } = useUpdateEncounterParticipant();
   const totalCr = R.sumBy(participantsInGroup, (p) =>
-    ParticipantUtils.challengeRating(p),
+    ParticipantUtils.challengeRating(p)
   );
   const tiers = EncounterUtils.findCRBudget({
     encounter,
@@ -1828,7 +1827,7 @@ const TurnGroupDisplay = observer(function TurnGroupDisplay({
         e.preventDefault();
         const droppedParticipant = typedDrag.get(
           e.dataTransfer,
-          dragTypes.participant,
+          dragTypes.participant
         );
         if (droppedParticipant) {
           updateParticipant({
@@ -2106,7 +2105,7 @@ const GroupTurnToggles = observer(function GroupTurnToggles() {
                   }
                 />
               </div>
-            ),
+            )
           )}
         </div>
       </div>
@@ -2125,18 +2124,18 @@ function FocusedTurnControls({
   const { mutate: toggleParticipantHasPlayedThisRound } = useToggleGroupTurn();
   const turnGroupsById = EncounterUtils.turnGroupsById(encounter);
   const focusedParticipant = encounter.participants.find(
-    (p) => p.id === focusedTurn.participantId,
+    (p) => p.id === focusedTurn.participantId
   );
 
   const label =
     focusedTurn.type === "group"
-      ? (turnGroupsById[focusedTurn.groupId]?.name ??
+      ? turnGroupsById[focusedTurn.groupId]?.name ??
         (focusedParticipant
           ? ParticipantUtils.name(focusedParticipant)
-          : "Turn"))
+          : "Turn")
       : focusedParticipant
-        ? ParticipantUtils.name(focusedParticipant)
-        : "Turn";
+      ? ParticipantUtils.name(focusedParticipant)
+      : "Turn";
 
   const turnGroup =
     focusedTurn.type === "group"
@@ -2192,7 +2191,7 @@ export const StatColumns = observer(function StatColumns() {
       <div
         className={clsx(
           "flex flex-col gap-2 h-full",
-          battleStyles.parentContainer,
+          battleStyles.parentContainer
         )}
       >
         {participantsByColumn[c.id]?.slice().map((p) => (
@@ -2405,7 +2404,7 @@ export const StatColumnComponent = observer(function StatColumnComponent({
           return ParticipantUtils.assignColumn(
             encounter,
             newColumn.column_id,
-            newColumn.participant_id,
+            newColumn.participant_id
           );
         });
         return { previousEncounter };
@@ -2463,7 +2462,7 @@ export const StatColumnComponent = observer(function StatColumnComponent({
         onDrop={(e) => {
           const droppedParticipant = typedDrag.get(
             e.dataTransfer,
-            dragTypes.participant,
+            dragTypes.participant
           );
           const droppedAsset = typedDrag.get(e.dataTransfer, dragTypes.asset);
 
@@ -2490,7 +2489,7 @@ export const StatColumnComponent = observer(function StatColumnComponent({
           e.stopPropagation();
           const hasParticipant = typedDrag.includes(
             e.dataTransfer,
-            dragTypes.participant,
+            dragTypes.participant
           );
           const hasAsset = typedDrag.includes(e.dataTransfer, dragTypes.asset);
 
@@ -2502,7 +2501,7 @@ export const StatColumnComponent = observer(function StatColumnComponent({
         onDragOver={(e) => {
           const hasParticipant = typedDrag.includes(
             e.dataTransfer,
-            dragTypes.participant,
+            dragTypes.participant
           );
           const hasAsset = typedDrag.includes(e.dataTransfer, dragTypes.asset);
 
@@ -2569,7 +2568,7 @@ export const StatColumnComponent = observer(function StatColumnComponent({
             "flex flex-col gap-3 w-full max-h-full h-full bg-white",
             {
               "bg-blue-500": acceptDrop > 0,
-            },
+            }
           )}
         >
           {children}
@@ -2601,11 +2600,11 @@ function StatColumnSplitter({ leftColumnIndex }: { leftColumnIndex: number }) {
     const currentColumns = getColumns.getData(encounterId);
     const leftColumnStart = currentColumns?.find((c) => c.id === leftColumnId);
     const rightColumnStart = currentColumns?.find(
-      (c) => c.id === rightColumnId,
+      (c) => c.id === rightColumnId
     );
     if (!leftColumnStart || !rightColumnStart) {
       throw new Error(
-        "no columns found when attempting to update percent width",
+        "no columns found when attempting to update percent width"
       );
     }
     let isPendingSetStateForFrame: number | null = null;

--- a/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx
+++ b/lidnd/app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx
@@ -108,6 +108,11 @@ import {
   SelectValue,
   SelectItem,
 } from "@/components/ui/select";
+import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
+} from "@/components/ui/popover";
 import { crLabel } from "@/utils/campaigns";
 import type { EncounterAsset, TurnGroup } from "@/server/db/schema";
 import { StatColumnUtils } from "@/utils/stat-columns";
@@ -271,13 +276,6 @@ export const EncounterBattleUI = observer(function BattleUI() {
                 </div>
               </div>
 
-              <div className="flex gap-3 flex-wrap items-center">
-                <EncounterPrepFormChooser
-                  activeForm={activePrepForm}
-                  onFormChange={setActivePrepForm}
-                  showTurnGroups={monsters.length > 0}
-                />
-              </div>
               {encounter.reminders?.length > 0 ? (
                 <div className="flex flex-col gap-3 w-full">
                   <ActiveReminders />
@@ -285,7 +283,14 @@ export const EncounterBattleUI = observer(function BattleUI() {
               ) : null}
 
               <div className="flex flex-wrap lg:flex-nowrap gap-5 items-start">
-                <EncounterPrepFormPanel activeForm={activePrepForm} />
+                <div className="w-full max-w-[500px] 2xl:w-[550px] 2xl:min-w-[550px] flex flex-col gap-3">
+                  <EncounterPrepFormChooser
+                    activeForm={activePrepForm}
+                    onFormChange={setActivePrepForm}
+                    showTurnGroups={monsters.length > 0}
+                  />
+                  <EncounterPrepFormPanel activeForm={activePrepForm} />
+                </div>
                 <div
                   className="w-full min-w-0 xl:max-h-full flex flex-col gap-3"
                   data-value="prep"
@@ -1444,7 +1449,7 @@ function EncounterPrepFormChooser({
   const secondaryChoices = choices.filter((c) => c.importance === "secondary");
 
   return (
-    <div className="flex w-full justify-between">
+    <div className="flex w-full justify-between gap-2">
       <div className="flex gap-2 flex-wrap items-center">
         {primaryChoices.map((choice) => (
           <Button
@@ -1458,19 +1463,35 @@ function EncounterPrepFormChooser({
           </Button>
         ))}
       </div>
-      <div className="flex gap-2 flex-wrap items-center text-gray-500 text-sm">
-        {secondaryChoices.map((choice) => (
-          <ButtonWithTooltip
-            key={choice.form}
-            variant={activeForm === choice.form ? "secondary" : "ghost"}
-            onClick={() => onFormChange(choice.form)}
-            className="gap-2"
-            text={choice.label}
+      <Popover>
+        <PopoverTrigger asChild>
+          <Button
+            variant="ghost"
+            className={clsx("gap-2", {
+              "bg-secondary text-secondary-foreground":
+                secondaryChoices.some((choice) => choice.form === activeForm),
+            })}
           >
-            {choice.icon}
-          </ButtonWithTooltip>
-        ))}
-      </div>
+            <MoreHorizontal className="h-5 w-5" />
+            More
+          </Button>
+        </PopoverTrigger>
+        <PopoverContent align="end" className="w-52 p-1">
+          <div className="flex flex-col">
+            {secondaryChoices.map((choice) => (
+              <Button
+                key={choice.form}
+                variant={activeForm === choice.form ? "secondary" : "ghost"}
+                onClick={() => onFormChange(choice.form)}
+                className="justify-start gap-2"
+              >
+                {choice.icon}
+                {choice.label}
+              </Button>
+            ))}
+          </div>
+        </PopoverContent>
+      </Popover>
     </div>
   );
 }
@@ -1481,7 +1502,7 @@ function EncounterPrepFormPanel({
   activeForm: EncounterPrepForm;
 }) {
   return (
-    <Card className="w-full max-w-[500px] 2xl:w-[550px] 2xl:min-w-[550px] min-h-[320px] h-full overflow-auto p-4 shadow-sm">
+    <Card className="w-full min-h-[320px] h-full overflow-auto p-4 shadow-sm">
       <div className="flex flex-col gap-4 h-full">
         {activeForm === "notes" && <DescriptionTextArea />}
         {activeForm === "participants" && <EditModeOpponentForm />}


### PR DESCRIPTION
### Motivation
- Make it visually clear which controls affect the encounter prep form by moving the action buttons directly above the form panel. 
- Reduce visual clutter by hiding less-used secondary actions behind a single dropdown.

### Description
- Moved `EncounterPrepFormChooser` so it sits directly above `EncounterPrepFormPanel` inside a shared left-column container to tie controls to the form area (`app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx`).
- Replaced the always-visible secondary icon buttons with a `More` popover that lists `partyMembers`, `images`, and `reminders` actions using `Popover`, `PopoverTrigger`, and `PopoverContent` from `components/ui/popover`.
- Kept active-state highlighting for secondary selections by styling the `More` trigger when any secondary form is active.
- Simplified the prep panel width classes by removing the previous `max-w` constraints on the `Card` so the chooser + panel share a single column container.

### Testing
- Ran `pnpm exec eslint app/[username]/[campaign_slug]/encounter/[encounter_index]/battle-ui.tsx` which completed successfully and reported one existing `react-hooks/exhaustive-deps` warning.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69eab39c81608320878be8edad63fc22)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Battle Prep UI Improvements

* **Refactor**
  * Reorganized the encounter prep UI layout with a dedicated sidebar container
  * Secondary form options are now accessible through a "More" menu instead of displaying inline
  * Enhanced visual styling to indicate which secondary form is currently active

<!-- end of auto-generated comment: release notes by coderabbit.ai -->